### PR TITLE
Change typo for PARTITION keyword in r_unload.md

### DIFF
--- a/doc_source/r_UNLOAD.md
+++ b/doc_source/r_UNLOAD.md
@@ -16,7 +16,7 @@ authorization
 
 where option is
 { [ FORMAT [ AS ] ] CSV | PARQUET
-| PARTITON BY ( column_name [, ... ] ) ]
+| PARTITION BY ( column_name [, ... ] ) ]
 | MANIFEST [ VERBOSE ] 
 | HEADER           
 | DELIMITER [ AS ] 'delimiter-char' 


### PR DESCRIPTION
PARTITION keyword is spelled out as PARTITON; commit fixes this.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
